### PR TITLE
Phase out http-server and use Caddy instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,5 @@ docs
 lib
 build
 node_modules
-cert.pem
-key.pem
 .env
 .DS_Store

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,8 @@
+{
+  auto_https  disable_redirects
+}
+
+localhost:8080 {
+  tls internal
+  file_server browse
+}

--- a/scripts/start-examples.sh
+++ b/scripts/start-examples.sh
@@ -1,18 +1,2 @@
-echo 'Checking SSL cert...'
-
-if [ -e cert.pem ] && [ -e key.pem ]; then
-  echo 'Cert found.'
-else
-  echo 'Cert not found.'
-  echo 'Creating SSL for local development...'
-
-  rm cert.pem key.pem
-
-  openssl genrsa 2048 > key.pem
-  openssl req -x509 -days 1000 -new -key key.pem -out cert.pem
-
-  echo 'Cert created.'
-fi
-
-echo 'Starting static server...'
-http-server --ssl -c-1
+echo 'Serving examples at https://localhost:8080/examples/'
+caddy run

--- a/scripts/start-examples.sh
+++ b/scripts/start-examples.sh
@@ -1,2 +1,11 @@
+#!/bin/bash
+
+if [[ $OSTYPE == "darwin"* ]]; then
+  sleep 1 && open https://localhost:8080/examples/ &>/dev/null
+elif command -v xdg-open &> /dev/null; then
+  sleep 1 && xdg-open https://localhost:8080/examples/ &>/dev/null
+fi
+
 echo 'Serving examples at https://localhost:8080/examples/'
 caddy run
+

--- a/scripts/start-examples.sh
+++ b/scripts/start-examples.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 if [[ $OSTYPE == "darwin"* ]]; then
-  sleep 1 && open https://localhost:8080/examples/ &>/dev/null
+  (sleep 1 && open https://localhost:8080/examples/ &>/dev/null) &
 elif command -v xdg-open &> /dev/null; then
-  sleep 1 && xdg-open https://localhost:8080/examples/ &>/dev/null
+  (sleep 1 && xdg-open https://localhost:8080/examples/ &>/dev/null) &
 fi
 
 echo 'Serving examples at https://localhost:8080/examples/'


### PR DESCRIPTION
since ecstatic is deprecated, now use caddy as static server instead for easier setup

@Zack0711 please install caddy before using: https://caddyserver.com/docs/download#macos