### PR TITLE
PORTAL-4496 API Test: ViberPlay.player.getConnectedPlayersAsync() new filter with pagination

### DIFF
--- a/examples/viber-play-demo/index.html
+++ b/examples/viber-play-demo/index.html
@@ -634,6 +634,15 @@ ViberPlay.shareAsync({
   ui: 'MULTIPLE',
 }).then((res) => console.log(res));
 </script>
+<script class="example-code" type="text/plain">
+ViberPlay.shareAsync({
+  playerIds: ["5743558323601408", "4899133393469440", "6143854107426816"],
+  intent: 'REQUEST',
+  image: createImg(1200, 1200),
+  text: 'This is share async test message',
+  data: {foo: 'bar'}
+}).then((res) => console.log(res));
+</script>
 </div>
 
 <div class="section">
@@ -703,6 +712,11 @@ ViberPlay.player.getConnectedPlayersAsync()
 </script>
 <script class="example-code" type="text/plain">
   ViberPlay.player.getConnectedPlayersAsync({filter: 'INCLUDE_NON_PLAYERS'})
+    .then((players) => console.log(JSON.stringify(players.map(player =>
+      ({id: player.getID(), name: player.getName(), photo: player.getPhoto(), hasPlayed: player.hasPlayed()})))));
+</script>
+<script class="example-code" type="text/plain">
+  ViberPlay.player.getConnectedPlayersAsync({filter: 'NEW_INVITATIONS_ONLY', cursor: 0, size: 25, hoursSinceInvitation: 4})
     .then((players) => console.log(JSON.stringify(players.map(player =>
       ({id: player.getID(), name: player.getName(), photo: player.getPhoto(), hasPlayed: player.hasPlayed()})))));
 </script>

--- a/src/sdk/player.ts
+++ b/src/sdk/player.ts
@@ -14,7 +14,7 @@ import {
   SubscribeBotResponse,
 } from '../types/bridge';
 
-import { GetConnectedPlayerPayload } from '../types/player'
+import { GetConnectedPlayersPayload } from '../types/player'
 
 /**
  * Get game data from platform storage.
@@ -193,7 +193,7 @@ export function getSignedPlayerInfoAsync (payload?: string): Promise<SignedPlaye
  *   })
  * ```
  */
-export function getConnectedPlayersAsync (payload:GetConnectedPlayerPayload = {}): Promise<Array<ConnectedPlayer>> {
+export function getConnectedPlayersAsync (payload:GetConnectedPlayersPayload = {}): Promise<Array<ConnectedPlayer>> {
   return conn
   .request<PlayerGetConnectedPlayersResponse>('sgPlayerGetConnectedPlayers', { ...payload })
   .then((res: { data: PlayerRawData[] }) => {

--- a/src/sdk/player.ts
+++ b/src/sdk/player.ts
@@ -186,9 +186,9 @@ export function getSignedPlayerInfoAsync (payload?: string): Promise<SignedPlaye
  *   })
  * ```
  */
-export function getConnectedPlayersAsync ({ filter = 'INCLUDE_PLAYERS' } = {}): Promise<Array<ConnectedPlayer>> {
+export function getConnectedPlayersAsync (payload = {}): Promise<Array<ConnectedPlayer>> {
   return conn
-  .request<PlayerGetConnectedPlayersResponse>('sgPlayerGetConnectedPlayers', { filter })
+  .request<PlayerGetConnectedPlayersResponse>('sgPlayerGetConnectedPlayers', { ...payload })
   .then((res: { data: PlayerRawData[] }) => {
     const players = res.data.map((profile: PlayerRawData) => new ConnectedPlayer(profile));
 

--- a/src/sdk/player.ts
+++ b/src/sdk/player.ts
@@ -14,6 +14,8 @@ import {
   SubscribeBotResponse,
 } from '../types/bridge';
 
+import { GetConnectedPlayerPayload } from '../types/player'
+
 /**
  * Get game data from platform storage.
  * @param keys - An array of unique keys to retrieve data for.
@@ -171,11 +173,16 @@ export function getSignedPlayerInfoAsync (payload?: string): Promise<SignedPlaye
 
 /**
  * This returns an array containing the friends of the user who has played the current game before.
+ * @param payload Additional parameters to fine-tune the result.
  * @returns Array of connected players
  * @example
  * ```
- * ViberPlay.player.getConnectedPlayersAsync()
- *   .then(players => {
+ * ViberPlay.player.getConnectedPlayersAsync({
+ *   filter: 'NEW_INVITATIONS_ONLY',
+ *   cursor: 0,
+ *   size: 20,
+ *   hoursSinceInvitation: 4,
+ * }).then(players => {
  *     console.log(players.map(player => {
  *       return {
  *         id: player.getID(),
@@ -186,7 +193,7 @@ export function getSignedPlayerInfoAsync (payload?: string): Promise<SignedPlaye
  *   })
  * ```
  */
-export function getConnectedPlayersAsync (payload = {}): Promise<Array<ConnectedPlayer>> {
+export function getConnectedPlayersAsync (payload:GetConnectedPlayerPayload = {}): Promise<Array<ConnectedPlayer>> {
   return conn
   .request<PlayerGetConnectedPlayersResponse>('sgPlayerGetConnectedPlayers', { ...payload })
   .then((res: { data: PlayerRawData[] }) => {

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -7,7 +7,7 @@ import { PlayerRawData } from './player'
  *
  * `NEW_CONTEXT_ONLY` only enlists contexts that the current player is in, but never participated in (e.g. a new context created by a friend).
  * `INCLUDE_EXISTING_CHALLENGES` enlists contexts that the current player has participated before.
- * `NEW_PLAYERS_ONLY` only enlists fiends who haven't played this game before.
+ * `NEW_PLAYERS_ONLY` only enlists friends who haven't played this game before.
  * `NEW_INVITATIONS_ONLY` only enlists friends who haven't been sent an in-game message before. This filter can be fine-tuned with `hoursSinceInvitation` parameter.
  */
 export type ContextFilter = 'NEW_CONTEXT_ONLY'

--- a/src/types/player.ts
+++ b/src/types/player.ts
@@ -41,7 +41,7 @@ export type ConnectedPlayerFilter = 'ALL'
   | 'INCLUDE_NON_PLAYERS'
   | 'NEW_INVITATIONS_ONLY'
 
-export interface GetConnectedPlayerPayload {
+export interface GetConnectedPlayersPayload {
   /**
    * Filter to be applied to the friend list.
    */

--- a/src/types/player.ts
+++ b/src/types/player.ts
@@ -27,3 +27,41 @@ export interface InitializeResponsePlayer {
   photo: string,
   connectedPlayers: PlayerRawData[],
 }
+
+/**
+ * Defines the filtering behavior
+ *
+ * `ALL` enlists all friends.
+ * `INCLUDE_PLAYERS` only enlists friends who have played this game before.
+ * `INCLUDE_NON_PLAYERS` only enlists friends who haven't played this game before.
+ * `NEW_INVITATIONS_ONLY` only enlists friends who haven't been sent an in-game message before. This filter can be fine-tuned with `hoursSinceInvitation` parameter and return list is depended on `cursor` and `size` parameter.
+ */
+export type ConnectedPlayerFilter = 'ALL'
+  | 'INCLUDE_PLAYERS'
+  | 'INCLUDE_NON_PLAYERS'
+  | 'NEW_INVITATIONS_ONLY'
+
+export interface GetConnectedPlayerPayload {
+  /**
+   * Filter to be applied to the friend list.
+   */
+  filter?: ConnectedPlayerFilter
+  /**
+   * Specify how long a friend should be filtered out after the current player sends him/her a message.
+   * This parameter only applies when `NEW_INVITATIONS_ONLY` filter is used.
+   * When not specified, it will filter out any friend who has been sent a message.
+   */
+  hoursSinceInvitation?: number,
+  /**
+   * Specify where to start fetch the friend list.
+   * This parameter only applies when `NEW_INVITATIONS_ONLY` filter is used.
+   * When not specified with `NEW_INVITATIONS_ONLY` filter, default cursor is 0.
+   */
+  cursor?: number,
+  /**
+   * Specify how many friends to be returned in the friend list.
+   * This parameter only applies when `NEW_INVITATIONS_ONLY` filter is used.
+   * When not specified with `NEW_INVITATIONS_ONLY` filter, default cursor is 25.
+   */
+  size?: number,  
+}

--- a/src/types/share-payload.ts
+++ b/src/types/share-payload.ts
@@ -45,4 +45,8 @@ export interface SharePayload {
   ui?: 'DEFAULT' | 'MULTIPLE',
   /** Text of the call to action button. If not specified, "Play" will be used by default. */
   cta?: string | LocalizableContent,  
+  /**
+   * Optional property to directly send share messages to mutiple players.
+  */
+  playerIds?: string[]
 }

--- a/src/types/share-payload.ts
+++ b/src/types/share-payload.ts
@@ -46,7 +46,7 @@ export interface SharePayload {
   /** Text of the call to action button. If not specified, "Play" will be used by default. */
   cta?: string | LocalizableContent,  
   /**
-   * Optional property to directly send share messages to mutiple players.
+   * Optional property to directly send share messages to mutiple players with a confirmation prompt. Selection UI will be skipped if this property is set.
   */
   playerIds?: string[]
 }


### PR DESCRIPTION
- Modify getConnectedPlayerAsync method, make it can accept more options. Bridge will use `INCLUDE_PLAYERS` as default filter when filter is not provided in payload, so I removed default filter assignment in SDK.
- Add playerIds to sharePayload.
- Update example codes of getConnectedPlayerAsync and shareAsync

Ticket: https://rgames.atlassian.net/browse/PORTAL-4496
Testable Game on qa: https://qa.vbrpl.io/play/AhYmRhb4Z0fgKZ1w2d1oybLI98JLK0g4/debug